### PR TITLE
Restore green/red colors to win/loss game icons

### DIFF
--- a/site.css
+++ b/site.css
@@ -394,8 +394,14 @@ span.chess-icon {
     font-size: 24px;
 }
 
-span.chess-icon-won::before,
-span.chess-icon-lost::before,
+span.chess-icon-won::before {
+    color: #3fb950;
+}
+
+span.chess-icon-lost::before {
+    color: #e5534b;
+}
+
 span.chess-icon-draw::before {
     color: var(--color-midnight-ink);
 }


### PR DESCRIPTION
## Summary

- После редизайна иконки результатов игр (победа/поражение/ничья) стали одинаково чёрными
- Восстановлены цвета: зелёный для побед, красный для поражений, нейтральный для ничьих

## Changes

В `site.css` одно общее правило с `color: var(--color-midnight-ink)` разделено на три отдельных:

| Результат | Цвет |
|-----------|------|
| Победа | `#3fb950` (зелёный, совпадает с `--color-green-tag`) |
| Поражение | `#e5534b` (красный) |
| Ничья | `var(--color-midnight-ink)` (нейтральный) |

## Test plan

- [ ] Открыть список игр любого пользователя
- [ ] Убедиться, что иконки побед — зелёные
- [ ] Убедиться, что иконки поражений — красные
- [ ] Убедиться, что иконки ничьих — нейтральные

---
_Generated by [Claude Code](https://claude.ai/code/session_01CguBQoz1AGkPmEpJwiogGo)_