### PR TITLE
Restore green/red colors to rating change display

### DIFF
--- a/site.css
+++ b/site.css
@@ -364,14 +364,21 @@ td.time {
     font-size: 11px;
 }
 
-.rating-climb,
+.rating-climb {
+    color: #3fb950;
+    font-weight: 500;
+}
+
+.rating-fall {
+    color: #e5534b;
+}
+
 .green,
 .blue {
     color: var(--color-midnight-ink);
     font-weight: 500;
 }
 
-.rating-fall,
 .red,
 .yellow {
     color: var(--color-stone);


### PR DESCRIPTION
## Summary

- Рейтинг в колонке Rating потерял цвета после редизайна
- Восстановлены цвета: зелёный когда рейтинг вырос, красный когда упал

## Changes

В `site.css` классы `.rating-climb` и `.rating-fall` отделены от `.green/.blue` и `.red/.yellow` и получили явные цвета:

| Класс | Цвет |
|-------|------|
| `.rating-climb` | `#3fb950` (зелёный) |
| `.rating-fall` | `#e5534b` (красный) |

## Test plan

- [ ] Открыть статистику игрока у которого рейтинг вырос — число должно быть зелёным
- [ ] Открыть статистику игрока у которого рейтинг упал — число должно быть красным

---
_Generated by [Claude Code](https://claude.ai/code/session_01CguBQoz1AGkPmEpJwiogGo)_